### PR TITLE
Use the mean from priors as the initial in dynamic_inference

### DIFF
--- a/test/dynamicHMC.jl
+++ b/test/dynamicHMC.jl
@@ -17,8 +17,8 @@ sol = solve(prob1,Tsit5())
 randomized = VectorOfArray([(sol(t[i]) + σ * randn(2)) for i in 1:length(t)])
 data = convert(Array,randomized)
 
-bayesian_result = dynamichmc_inference(prob1, data, [Normal(1.5, 1)], t, [bridge(ℝ, ℝ⁺, )], [2.0])
-@test mean(bayesian_result[1]) ≈ 1.5 atol=1e-1
+bayesian_result = dynamichmc_inference(prob1, data, [Normal(1.5, 1)], t, [bridge(ℝ, ℝ⁺, )])
+@test mean(bayesian_result[1][1]) ≈ 1.5 atol=1e-1
 
 f1 = @ode_def_nohes LotkaVolterraTest4 begin
   dx = a*x - b*x*y
@@ -35,8 +35,8 @@ data = convert(Array,randomized)
 priors = [Truncated(Normal(1.5,0.01),0,2),Truncated(Normal(1.0,0.01),0,1.5),
           Truncated(Normal(3.0,0.01),0,4),Truncated(Normal(1.0,0.01),0,2)]
 
-bayesian_result = dynamichmc_inference(prob1, data, priors, t, [bridge(ℝ, ℝ⁺, ),bridge(ℝ, ℝ⁺, ),bridge(ℝ, ℝ, ),bridge(ℝ, ℝ⁺, )], [1.5,1.0,3.0,1.0])
-@test mean(bayesian_result[1]) ≈ 1.5 atol=1e-1
-@test mean(bayesian_result[2]) ≈ 1.0 atol=1e-1
-@test mean(bayesian_result[3]) ≈ 3.0 atol=1e-1
-@test mean(bayesian_result[4]) ≈ 1.0 atol=1e-1 
+bayesian_result = dynamichmc_inference(prob1, data, priors, t, [bridge(ℝ, ℝ⁺, ),bridge(ℝ, ℝ⁺, ),bridge(ℝ, ℝ, ),bridge(ℝ, ℝ⁺, )])
+@test mean(bayesian_result[1][1]) ≈ 1.5 atol=1e-1
+@test mean(bayesian_result[1][2]) ≈ 1.0 atol=1e-1
+@test mean(bayesian_result[1][3]) ≈ 3.0 atol=1e-1
+@test mean(bayesian_result[1][4]) ≈ 1.0 atol=1e-1 


### PR DESCRIPTION
Previously the user had to pass the initial values manually, instead now the mean of the priors will be used as the initial value. Also added some more variables being returned by dynamic_inference for better analysis.