### PR TITLE
RFC: Allow custom likelihood for dynamichmc_inference

### DIFF
--- a/src/abc_inference.jl
+++ b/src/abc_inference.jl
@@ -1,22 +1,22 @@
-function createabcfunction(prob, t, distancefunction, alg, kwargs...)
-    function simfunc(params, constants, targetdata)
-        sol = solve(problem_new_parameters(prob, params), alg, saveat = t, save_start = false, kwargs...)
-        data = convert(Array, sol)
-        distancefunction(targetdata, data), data
+function createabcfunction(prob, t, distancefunction, alg; kwargs...)
+    function simfunc(params, constants, data)
+        sol = solve(problem_new_parameters(prob, params), alg; saveat = t, save_start = false, kwargs...)
+        simdata = convert(Array, sol)
+        distancefunction(data, simdata), nothing
     end
 end
 
 function abc_inference(prob::DEProblem, alg, t, data, priors; ϵ=0.001,
-     distancefunction = euclidean, ABCalgorithm = ABCSMC, progress = false,
-     num_samples = 500, maxiterations = 10^5, kwargs...)
+                       distancefunction = euclidean, ABCalgorithm = ABCSMC, progress = false,
+                       num_samples = 500, maxiterations = 10^5, kwargs...)
 
-    abcsetup = ABCalgorithm(createabcfunction(prob, t, distancefunction, alg, kwargs...),
-     length(priors),
-     ϵ,
-     ApproxBayes.Prior(priors);
-     nparticles = num_samples,
-     maxiterations = maxiterations
-    )
+    abcsetup = ABCalgorithm(createabcfunction(prob, t, distancefunction, alg; kwargs...),
+                            length(priors),
+                            ϵ,
+                            ApproxBayes.Prior(priors);
+                            nparticles = num_samples,
+                            maxiterations = maxiterations
+                            )
 
     abcresult = runabc(abcsetup, data, progress = progress)
     return abcresult

--- a/src/dynamichmc_inference.jl
+++ b/src/dynamichmc_inference.jl
@@ -1,38 +1,48 @@
 struct DynamicHMCPosterior
-    problem
-    data
-    a_prior
-    t
-    ϵ_dist
     alg
+    problem
+    likelihood
+    priors
     kwargs
 end
 
-function (P::DynamicHMCPosterior)(θ)
-    #println(θ)
-    @unpack problem, data, a_prior, t, ϵ_dist, alg, kwargs = P
-    a = θ
-    try
-        prob = problem_new_parameters(problem, a)
-        sol = solve(prob, alg; kwargs...)
-        ℓ = sum(sum(logpdf.(ϵ_dist, sol(t) .- data[:, i]))
-                for (i, t) in enumerate(t))
-    catch
+function (P::DynamicHMCPosterior)(a)
+    @unpack alg, problem, likelihood, priors, kwargs = P
+
+    prob = problem_new_parameters(problem, a)
+    sol = solve(prob, alg; kwargs...)
+    if any((s.retcode != :Success for s in sol))
         ℓ = -Inf
+    else
+        ℓ = likelihood(sol)
     end
+
     if !isfinite(ℓ) && (ℓ ≠ -Inf)
         ℓ = -Inf                # protect against NaN etc, is it needed?
     end
     logpdf_sum = 0
     for i in length(a)
-        logpdf_sum += logpdf(a_prior[i], a[i])
+        logpdf_sum += logpdf(priors[i], a[i])
     end
     ℓ + logpdf_sum
 end
 
+
 function dynamichmc_inference(prob::DEProblem, alg, t, data, priors, transformations;
-                              σ=0.01, ϵ=0.001, initial=Float64[], num_samples=1000, kwargs...)
-    P = DynamicHMCPosterior(prob, data, priors, t, Normal(0.0, σ), alg, kwargs)
+                              σ=0.01, ϵ=0.001, initial=Float64[], num_samples=1000,
+                              kwargs...)
+    likelihood = sol -> sum( sum(logpdf.(Normal(0.0, σ), sol(t) .- data[:, i]))
+                             for (i, t) in enumerate(t) )
+
+    dynamichmc_inference(prob::DEProblem, alg, likelihood, priors, transformations;
+                         ϵ=ϵ, initial=initial, num_samples=num_samples,
+                         kwargs...)
+end
+
+function dynamichmc_inference(prob::DEProblem, alg, likelihood, priors, transformations;
+                              ϵ=0.001, initial=Float64[], num_samples=1000,
+                              kwargs...)
+    P = DynamicHMCPosterior(alg, prob, likelihood, priors, kwargs)
 
     transformations_tuple = Tuple(transformations)
     parameter_transformation = TransformationTuple(transformations_tuple) # assuming a > 0
@@ -43,14 +53,14 @@ function dynamichmc_inference(prob::DEProblem, alg, t, data, priors, transformat
     upper_bound = Float64[]
 
     for i in priors
-        push!(lower_bound,minimum(i))
-        push!(upper_bound,maximum(i))
+        push!(lower_bound, minimum(i))
+        push!(upper_bound, maximum(i))
     end
 
+    # If no initial position is given use local minimum near expectation of priors.
     if length(initial) == 0
-        # If no initial position is given use local minimum near expectation of priors.
         for i in priors
-            push!(initial,mean(i))
+            push!(initial, mean(i))
         end
         initial = Optim.minimizer(optimize(a -> -P(a),initial,lower_bound,upper_bound,Fminbox{GradientDescent}()))
     end

--- a/test/dynamicHMC.jl
+++ b/test/dynamicHMC.jl
@@ -21,15 +21,15 @@ bayesian_result = dynamichmc_inference(prob1, Tsit5(), t, data, [Normal(1.5, 1)]
 @test mean(bayesian_result[1][1]) ≈ 1.5 atol=1e-1
 
 # With hand-code likelihood function
-weights = ones(data) # weighted data
+weights_ = ones(data) # weighted data
 for i = 1:3:length(data)
-    weights[i] = 0
+    weights_[i] = 0
     data[i] = 1e20 # to test that those points are indeed not used
 end
 likelihood = function (sol)
     l = 0.0
     for (i, t) in enumerate(t)
-        l += sum(logpdf.(Normal(0.0, σ), sol(t) - data[:, i]) .* weights[:,i])
+        l += sum(logpdf.(Normal(0.0, σ), sol(t) - data[:, i]) .* weights_[:,i])
     end
     return l
 end

--- a/test/dynamicHMC.jl
+++ b/test/dynamicHMC.jl
@@ -20,6 +20,23 @@ data = convert(Array,randomized)
 bayesian_result = dynamichmc_inference(prob1, Tsit5(), t, data, [Normal(1.5, 1)], [bridge(ℝ, ℝ⁺, )])
 @test mean(bayesian_result[1][1]) ≈ 1.5 atol=1e-1
 
+# With hand-code likelihood function
+weights = ones(data) # weighted data
+for i = 1:3:length(data)
+    weights[i] = 0
+    data[i] = 1e20 # to test that those points are indeed not used
+end
+likelihood = function (sol)
+    l = 0.0
+    for (i, t) in enumerate(t)
+        l += sum(logpdf.(Normal(0.0, σ), sol(t) - data[:, i]) .* weights[:,i])
+    end
+    return l
+end
+bayesian_result = dynamichmc_inference(prob1, Tsit5(), likelihood, [Truncated(Normal(1.5, 1), 0, 2)], [bridge(ℝ, ℝ⁺, )])
+@test mean(bayesian_result[1][1]) ≈ 1.5 atol=1e-1
+
+
 f1 = @ode_def_nohes LotkaVolterraTest4 begin
   dx = a*x - b*x*y
   dy = -c*y + d*x*y


### PR DESCRIPTION
This lets one choose a custom likelihood for `dynamichmc_inference`.  Not sure if this is in-line with the rest of the parameter-estimation functionality. 

TODO: add some docs.