### PR TITLE
Fix Turing support

### DIFF
--- a/src/DiffEqBayes.jl
+++ b/src/DiffEqBayes.jl
@@ -1,5 +1,5 @@
 module DiffEqBayes
-using DiffEqBase, Distributions, Turing, MacroTools, Mamba
+using DiffEqBase, Distributions, Turing, MacroTools#, Mamba
 using ParameterizedFunctions, RecursiveArrayTools
 using Parameters, Distributions, Optim, Requires
 using Distances, ApproxBayes, DocStringExtensions, Random

--- a/src/turing_inference.jl
+++ b/src/turing_inference.jl
@@ -1,86 +1,55 @@
-function turing_inference(prob::DiffEqBase.DEProblem,alg,t,data,priors;
-  likelihood_dist_priors = [InverseGamma(2, 3)],
-  likelihood = (u,p,t,σ) -> MvNormal(u, σ[1]*ones(length(u))),
-  num_samples=1000, sampler = Turing.NUTS(0.65),
-  syms = [Symbol("theta$i") for i in 1:length(priors)],
-  kwargs...)
-
-  N = length(priors)
-  mf(vi,sampler,model) = begin
-    # If x is provided, use the provided values.
-    # Otherwise, treat x as an empty vector with
-    # two entries.
-    x = model.defaults.x
-
+function turing_inference(
+    prob::DiffEqBase.DEProblem,
+    alg,
+    t,
+    data,
+    priors;
+    likelihood_dist_priors = [InverseGamma(2, 3)],
+    likelihood = (u,p,t,σ) -> MvNormal(u, σ[1]*ones(length(u))),
+    num_samples=1000, sampler = Turing.NUTS(0.65),
+    syms = [Turing.@varname(theta[i]) for i in 1:length(priors)],
+    kwargs...,
+)
     N = length(priors)
-    _theta = Vector(undef,length(priors))
-
-    for i in 1:length(priors)
-      _theta[i], __lp = Turing.assume(sampler,
-                        priors[i],
-                        Turing.VarName([:mf, syms[i]], ""),
-                        vi)
-      vi.logp += __lp
-    end
-
-    theta = convert(Array{typeof(first(_theta))},_theta)
-    _σ = Vector(undef,length(likelihood_dist_priors))
-
-    for i in 1:length(likelihood_dist_priors)
-      _σ[i], __lp = Turing.assume(sampler,
-                      likelihood_dist_priors[i],
-                      Turing.VarName([:mf, Symbol("σ$i")], ""),
-                      vi)
-      vi.logp += __lp
-    end
-    σ = convert(Array{typeof(first(_σ))},_σ)
-
-    p_tmp = remake(prob, u0 = convert.(eltype(theta), (prob.u0)), p = theta)
-    _saveat = t === nothing ? Float64[] : t
-    sol_tmp = solve(p_tmp, alg; saveat = _saveat, kwargs...)
-
-    if sol_tmp isa DiffEqBase.AbstractEnsembleSolution
-      failure = any((s.retcode != :Success for s in sol_tmp)) && any((s.retcode != :Terminated for s in sol_tmp))
-    else
-      failure = sol_tmp.retcode != :Success && sol_tmp != :Terminated
-    end
-
-    if failure
-      vi.logp -= Inf
-    else
-      if sol_tmp isa DiffEqBase.AbstractNoTimeSolution
-        res = sol_tmp.u
-        __lp = Turing.observe(
-          sampler,
-          likelihood(res,theta,Inf,σ),   # Distribution
-          x,    # Data point
-          vi
-        )
-        vi.logp += __lp
-      else
-        for i = 1:length(t)
-          res = sol_tmp.u[i]
-          _t   = sol_tmp.t[i]
-          __lp = Turing.observe(
-            sampler,
-            likelihood(res,theta,_t,σ),   # Distribution
-            x[:,i],    # Data point
-            vi
-          )
-          vi.logp += __lp
+    Turing.@model mf(x, ::Type{T} = Float64) where {T <: Real} = begin
+        theta = Vector{T}(undef, length(priors))
+        for i in 1:length(priors)
+            theta[i] ~ NamedDist(priors[i], syms[i])
         end
-      end
+        σ = Vector{T}(undef, length(likelihood_dist_priors))
+        for i in 1:length(likelihood_dist_priors)
+            σ[i] ~ likelihood_dist_priors[i]
+        end
+        p_tmp = remake(prob, u0 = convert.(T, (prob.u0)), p = theta)
+        _saveat = t === nothing ? Float64[] : t
+        sol_tmp = solve(p_tmp, alg; saveat = _saveat, kwargs...)
+
+        if sol_tmp isa DiffEqBase.AbstractEnsembleSolution
+            failure = any((s.retcode != :Success for s in sol_tmp)) && any((s.retcode != :Terminated for s in sol_tmp))
+        else
+            failure = sol_tmp.retcode != :Success && sol_tmp != :Terminated
+        end
+
+        if failure
+            @logpdf() = -Inf
+            return
+        end
+        if sol_tmp isa DiffEqBase.AbstractNoTimeSolution
+            res = sol_tmp.u
+            x ~ likelihood(res, theta, Inf, σ)
+        else
+            u = sol_tmp.u
+            for i = 1:length(t)
+                res = sol_tmp.u[i]
+                _t = sol_tmp.t[i]
+                x[:,i] ~ likelihood(res, theta, _t, σ)
+            end
+        end
+        return 
     end
-    vi
-  end
 
-  bigtup = Tuple{([[syms[i] for i in 1:length(priors)]; [Symbol("σ$i") for i in 1:length(likelihood_dist_priors)]])...}
-
-  # Define the default value for x when missing
-  defaults = (x = data,)
-
-  # Instantiate a Model object.
-  model = Turing.Model{bigtup, Tuple{:x}}(mf, data, defaults)
-
-  chn = sample(model, sampler, num_samples)
+    # Instantiate a Model object.
+    model = mf(data)
+    chn = sample(model, sampler, num_samples)
+    return chn
 end

--- a/test/turing.jl
+++ b/test/turing.jl
@@ -2,8 +2,8 @@ using DiffEqBayes, OrdinaryDiffEq, ParameterizedFunctions, RecursiveArrayTools
 using Test, Distributions, SteadyStateDiffEq
 println("One parameter case")
 f1 = @ode_def begin
-  dx = a*x - x*y
-  dy = -3y + x*y
+    dx = a*x - x*y
+    dy = -3y + x*y
 end a
 u0 = [1.0,1.0]
 tspan = (0.0,10.0)
@@ -23,8 +23,8 @@ bayesian_result = turing_inference(prob1,Tsit5(),t,data,priors;num_samples=500,
 
 println("Four parameter case")
 f2 = @ode_def begin
-  dx = a*x - b*x*y
-  dy = -c*y + d*x*y
+    dx = a*x - b*x*y
+    dy = -c*y + d*x*y
 end a b c d
 u0 = [1.0,1.0]
 tspan = (0.0,10.0)
@@ -34,8 +34,8 @@ sol = solve(prob2,Tsit5())
 t = collect(range(1,stop=10,length=10))
 randomized = VectorOfArray([(sol(t[i]) + .01randn(2)) for i in 1:length(t)])
 data = convert(Array,randomized)
-priors = [Truncated(Normal(1.5,0.01),0,2),Truncated(Normal(1.0,0.01),0,1.5),
-          Truncated(Normal(3.0,0.01),0,4),Truncated(Normal(1.0,0.01),0,2)]
+priors = [truncated(Normal(1.5,0.01),0,2),truncated(Normal(1.0,0.01),0,1.5),
+          truncated(Normal(3.0,0.01),0,4),truncated(Normal(1.0,0.01),0,2)]
 
 bayesian_result = turing_inference(prob2,Tsit5(),t,data,priors;num_samples=500,
                                    syms = [:a,:b,:c,:d])
@@ -63,7 +63,7 @@ s_sol = solve(s_prob,DynamicSS(Tsit5(),abstol=1e-4,reltol=1e-3))
 
 # true data is 1.00, 0.25
 data = [1.05, 0.23]
-priors = [Truncated(Normal(2.0,0.2),0,3)]
+priors = [truncated(Normal(2.0,0.2),0,3)]
 bayesian_result = turing_inference(s_prob,DynamicSS(Tsit5(),abstol=1e-4,reltol=1e-3),
                                    nothing,data,priors;
                                    num_samples=500,


### PR DESCRIPTION
This PR makes DiffEqBayes and the latest Turing compatible and simplifies the Turing code in DiffEqBayes. Mamba seems to be causing a stackoverflow from the type piracy in https://github.com/brian-j-smith/Mamba.jl/blob/master/src/distributions/constructors.jl. I commented it out for now.

Relevant: #123, #125