### PR TITLE
Remove plot_chain

### DIFF
--- a/src/DiffEqBayes.jl
+++ b/src/DiffEqBayes.jl
@@ -23,11 +23,6 @@ function __init__()
         include("dynamichmc_inference.jl")
         export dynamichmc_inference
     end
-
-    @require StatsPlots="f3b207a7-027a-5e70-b257-86293d7955fd" begin
-        include("utils.jl")
-        export plot_chain
-    end
 end
 
 export turing_inference, abc_inference

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,0 @@
-function plot_chain(bayesian_result::T,filename=nothing) where {T<:MCMCChains.Chains}
-	StatsPlots.plot(bayesian_result)
-end


### PR DESCRIPTION
This function does not seem to be very useful, but maybe there's a reason for having it in DiffEqBayes?