### PR TITLE
Remove allow-reresolve input from central Downgrade caller

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -19,5 +19,4 @@ jobs:
     with:
       julia-version: "1.10"
       skip: "Pkg,TOML"
-      allow-reresolve: false
     secrets: "inherit"


### PR DESCRIPTION
## Summary

The central reusable workflow `SciML/.github/.github/workflows/downgrade.yml@v1` was retagged with the `allow-reresolve` `workflow_call` input **removed**. The `.github/workflows/Downgrade.yml` caller in this repo still passes `allow-reresolve: false` in its `with:` block, which now references an undefined input and causes the downgrade job to **error** on workflow validation.

This PR removes only that single line so the caller passes only inputs the v1 workflow still accepts (`julia-version`, `skip`).

## Diff

```diff
     with:
       julia-version: "1.10"
       skip: "Pkg,TOML"
-      allow-reresolve: false
     secrets: "inherit"
```

`git show --stat` confirms only the workflow file line removal (1 file changed, 1 deletion).

Note: the downgrade job is still gated by `if: false` (disabled per #370), so this is a forward-looking correctness fix to keep the caller valid under the retagged v1 workflow.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)