### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -16,7 +16,6 @@ jobs:
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
+      julia-version: "lts"
       group: "Core"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Canonical CI cleanup

- **TagBot.yml**: replaced the inlined `JuliaRegistries/TagBot@v1` action (with its hand-written permissions block and steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1` (`secrets: inherit`).
- **Downgrade.yml**: removed the hand-listed `skip: "Pkg,TOML"` input (both are Julia stdlibs; the centralized downgrade workflow now auto-populates the skip list). Pinned `julia-version` to `"lts"` (the LTS is the minimum-supported floor).

This repo is not a monorepo (no registered `lib/<Name>` subpackages), so no TagBot subpackage matrix was added. `.typos.toml` already exists, so no SpellCheck starter was needed.

Ignore until reviewed by @ChrisRackauckas.