### PR TITLE
Use SciMLTesting v1.1.0 (run_tests) with curated All membership

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,6 +53,7 @@ RecursiveArrayTools = "4.3"
 Reexport = "1.0"
 Requires = "1.0"
 SciMLStructures = "1"
+SciMLTesting = "1"
 StanSample = "6, 7"
 StructArrays = "0.7"
 TransformVariables = "0.8"
@@ -66,9 +67,10 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADTypes", "Test", "Pkg", "OrdinaryDiffEq", "ParameterizedFunctions", "SafeTestsets", "StatsBase", "SteadyStateDiffEq"]
+test = ["ADTypes", "Test", "Pkg", "OrdinaryDiffEq", "ParameterizedFunctions", "SafeTestsets", "SciMLTesting", "StatsBase", "SteadyStateDiffEq"]

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -1,0 +1,9 @@
+using SafeTestsets
+
+@time @safetestset "DynamicHMC" begin
+    include("dynamicHMC.jl")
+end
+@time @safetestset "Turing" begin
+    include("turing.jl")
+end
+# @time @safetestset "ABC" begin include("abc.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,32 +1,24 @@
 using SafeTestsets
-const LONGER_TESTS = false
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "All")
-
-if GROUP == "All" || GROUP == "Core"
-    @time @safetestset "DynamicHMC" begin
-        include("dynamicHMC.jl")
-    end
-    @time @safetestset "Turing" begin
-        include("turing.jl")
-    end
-    # @time @safetestset "ABC" begin include("abc.jl") end
-end
-
-if GROUP == "Stan" || GROUP == "All"
-    @time @safetestset "Stan_String" begin
-        include("stan_string.jl")
-    end
-    @time @safetestset "Stan" begin
-        include("stan.jl")
-    end
-end
+const GROUP = current_group()
 
 if GROUP == "JET"
-    using Pkg
+    # The jet env is activated and instantiated but the repo root is NOT
+    # `Pkg.develop`ed (matching the original branch), so this keeps the explicit
+    # dispatch rather than run_tests' env mechanism (which always develops).
+    import Pkg
     Pkg.activate(joinpath(@__DIR__, "jet"))
     Pkg.instantiate()
     @time @safetestset "JET" begin
         include("jet/jet_tests.jl")
     end
+else
+    run_tests(;
+        core = joinpath(@__DIR__, "core_tests.jl"),
+        groups = Dict(
+            "Stan" => joinpath(@__DIR__, "stan_tests.jl"),
+        ),
+        all = ["Core", "Stan"],
+    )
 end

--- a/test/stan_tests.jl
+++ b/test/stan_tests.jl
@@ -1,0 +1,8 @@
+using SafeTestsets
+
+@time @safetestset "Stan_String" begin
+    include("stan_string.jl")
+end
+@time @safetestset "Stan" begin
+    include("stan.jl")
+end


### PR DESCRIPTION
Converts `test/runtests.jl` to the SciMLTesting **v1.1.0** `run_tests` dispatcher. This supersedes the v1.0.0 first pass on this branch.

## Behavior-equivalent mapping (identical test set per GROUP)

| GROUP | Runs |
|-------|------|
| `All` (default) | Core (`DynamicHMC`, `Turing`) + Stan (`Stan_String`, `Stan`) |
| `Core` | `DynamicHMC`, `Turing` |
| `Stan` | `Stan_String`, `Stan` |
| `JET` | `jet/jet_tests.jl` (jet env) |

- `core = test/core_tests.jl`, `Stan` group = `test/stan_tests.jl` (in-process, no env).
- Curated `all = ["Core", "Stan"]`: the original `All` branch ran Core + Stan and **never ran JET**, so JET is deliberately omitted from `all` (it stays selectable by `GROUP=JET`). This is the v1.1.0 correctness fix over the v1.0.0 first pass.
- **JET kept as an explicit branch**: the original `GROUP == "JET"` branch activated and instantiated the `jet` env but did **not** `Pkg.develop` the repo root. `run_tests`' `env=` mechanism always develops the root, which would change behavior, so the JET dispatch is preserved verbatim. `Pkg` therefore stays in the test deps.

## Project.toml
- Add `SciMLTesting` (`09d9d899-5365-40a9-917a-5f67fddea283`) to `[extras]`, `[compat] SciMLTesting = "1"`, and the `test` target.

Static-verified: `TOML.parsefile` on Project.toml and `Meta.parseall` on runtests.jl / core_tests.jl / stan_tests.jl / jet/jet_tests.jl all pass.

Ignore until reviewed by @ChrisRackauckas.