### PR TITLE
CI: drop Stan from centralized grouped-tests matrix (cmdstan unprovisionable)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,20 @@
 using SciMLTesting
-run_tests()
+
+# The Stan group is intentionally absent from test_groups.toml: it needs a cmdstan
+# build (.github/scripts/stan.sh + JULIA_CMDSTAN_HOME) that the centralized
+# grouped-tests.yml matrix cannot provision, so it must not appear as a centralized
+# job. Folder-discovery `run_tests()` only accepts groups declared in
+# test_groups.toml, so it would reject GROUP="Stan". The dedicated CI.yml workflow
+# (which runs stan.sh first) dispatches GROUP="Stan" here under `Pkg.test`, so the
+# test environment is already active; include the Stan folder's files directly.
+if get(ENV, "GROUP", "All") == "Stan"
+    using SafeTestsets: @safetestset
+    stan_dir = joinpath(@__DIR__, "Stan")
+    for file in sort!(filter(f -> endswith(f, ".jl"), readdir(stan_dir)))
+        @eval @safetestset $file begin
+            include(joinpath(@__DIR__, "Stan", $file))
+        end
+    end
+else
+    run_tests()
+end

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,7 +1,8 @@
+# The Stan group is NOT listed here: it requires a cmdstan build
+# (.github/scripts/stan.sh download + `make build` + JULIA_CMDSTAN_HOME) that the
+# centralized grouped-tests.yml caller cannot perform. The Stan group keeps its
+# full coverage through the dedicated CI.yml workflow, which runs stan.sh first.
 [Core]
-versions = ["lts", "1", "pre"]
-
-[Stan]
 versions = ["lts", "1", "pre"]
 
 [QA]


### PR DESCRIPTION
## Problem

Master CI has six failing checks. This PR fixes the **Stan** failures, which are the only cleanly-fixable ones.

Commit #385 ("Canonical CI: grouped-tests.yml + root test/test_groups.toml") did two things that combined into a regression:

1. Converted `Tests.yml` to call the centralized `SciML/.github/.github/workflows/grouped-tests.yml@v1` thin caller.
2. In a follow-up ("Restore dropped Stan test group in test_groups.toml") re-added a `[Stan]` group to `test/test_groups.toml`.

The centralized reusable workflow cannot run the bespoke cmdstan build (`.github/scripts/stan.sh`: download cmdstan + `make build` + export `JULIA_CMDSTAN_HOME`) — it only exposes `apt-packages`/`container`, neither of which installs cmdstan. The #385 commit message itself notes: *"CI.yml (the Stan group) is left untouched: its custom cmdstan build is not expressible in the canonical reusable workflow."*

So every `tests / Stan (julia lts|1|pre)` job spawned by the centralized matrix errors immediately:

```
Warning: Environment variable CMDSTAN_HOME not set. Use set_cmdstan_home!.
LoadError: IOError: cd(""): no such file or directory (ENOENT)
```

Meanwhile the dedicated `CI.yml` workflow runs the Stan group **correctly** (it runs `stan.sh` first, exports `JULIA_CMDSTAN_HOME`) and its `test (Stan, lts|pre)` jobs pass. Stan was therefore double-tested: correctly via `CI.yml`, brokenly via the centralized matrix.

## Fix

Remove `[Stan]` from `test/test_groups.toml` so the centralized `grouped-tests.yml` caller stops spawning the un-provisionable Stan lane. Stan keeps its **full** coverage through the dedicated `CI.yml` workflow. This is not a test skip — the Stan tests still run end-to-end with real cmdstan; only the structurally-broken duplicate lane is removed. This restores the green CI topology that existed immediately before #385 (commit `8b732d3`, which was green for Core/Stan).

## Local verification

Ran the actual root-matrix script from `SciML/.github@v1` against the edited `test_groups.toml`:

```
$ julia compute_affected_sublibraries.jl . --root-matrix
[Core/lts, Core/1, Core/pre, QA/lts, QA/1]   # no Stan entries
```

Before the edit it produced the three extra `Stan/{lts,1,pre}` entries (the failing lanes). The only matrix delta is the removal of those three Stan entries.

## Not addressed here (report-only, separate causes)

- **`Downgrade / Downgrade Tests - Core`** (`Unsatisfiable`): pre-existing, intentional RED, re-enabled strict in #381 ("natural RED pending Turing/DynamicPPL #370"). Failing on every run since 2026-06-07. Out of scope.
- **`tests / Core (julia pre)`** (`turing.jl:79`, `mean(u1) ≈ 1.0`, evaluated `1.1e-5`): the `sample_u0=true` MCMC test is **unseeded** (no `Random.seed!` in `test/turing.jl`); the inferred initial condition collapsed in this run's draw. Core passed on `julia 1`/`lts` here and was green at the prior commit. This is a flaky stochastic test, not addressed here (fixing it cleanly needs a seed, and per policy must not be masked by a tolerance bump).

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
