### PR TITLE
Fix undefined documentation matrix reference

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -21,7 +21,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-          GROUP: ${{ matrix.group }}
         run: julia --project=docs/ --code-coverage=user docs/make.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7


### PR DESCRIPTION
## Summary

- remove the undefined `matrix.group` reference from the documentation job
- keep the legitimate `GROUP` matrix selection in the dedicated Stan test workflow unchanged

## Root cause

The documentation job has no `strategy.matrix`. Commit `d1c164a80c01159a2cf706377e560a6d99f63de7` copied `GROUP: ${{ matrix.group }}` into that job in 2022, so current `actionlint` rejects the workflow. The docs job already installs CmdStan unconditionally and does not dispatch SciMLTesting groups, so this environment entry is unused.

## Local validation

- `actionlint .github/workflows/Documentation.yml` — passed
- `actionlint` — passed for all workflows
- `GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed (19 pass, 1 pre-existing broken, exit 0)
- `julia +1.12 --startup-file=no -m Runic --check .` — passed
- `git diff --check` — passed

Please ignore this PR until it has been reviewed by @ChrisRackauckas.