### PR TITLE
Bump DiffEqBayes to v3.14.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBayes"
 uuid = "ebbdde9d-f333-5424-9be2-dbf1e9acfb5e"
 authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
-version = "3.14.2"
+version = "3.14.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Bumps `DiffEqBayes` **v3.14.2 → v3.14.3** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Fix undefined documentation matrix reference (#398) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)