### PR TITLE
Add Turing.jl direct usage tutorial link (fixes #247)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,6 +15,13 @@ using Pkg
 Pkg.add("DiffEqBayes")
 ```
 
+## Direct Turing.jl Usage
+
+While DiffEqBayes.jl provides a simplified interface, users who want more control
+can use Turing.jl directly with DifferentialEquations.jl. See the
+[Turing.jl Bayesian Differential Equations tutorial](https://turinglang.org/docs/tutorials/bayesian-differential-equations/)
+for a complete guide on writing custom `@model` macros with ODE solvers.
+
 ## Contributing
 
   - Please refer to the

--- a/src/DiffEqBayes.jl
+++ b/src/DiffEqBayes.jl
@@ -3,13 +3,29 @@ $(DocStringExtensions.README)
 """
 module DiffEqBayes
 
-using DiffEqBase, Distributions, Turing, MacroTools
-import SciMLBase
-using RecursiveArrayTools, ModelingToolkit, LinearAlgebra
-using Parameters, Distributions, Optim, Requires
-using Distances, DocStringExtensions, Random, StanSample
-using DynamicHMC, TransformVariables, LogDensityProblemsAD, TransformedLogDensities
-using SciMLStructures
+using DiffEqBase: DiffEqBase, EnsembleProblem, SciMLBase, remake
+using Distances: Distances
+using DocStringExtensions: DocStringExtensions, FIELDS, SIGNATURES, TYPEDEF
+using DynamicHMC: DynamicHMC, mcmc_with_warmup
+using LinearAlgebra: LinearAlgebra, Diagonal
+using LogDensityProblemsAD: LogDensityProblemsAD
+using MacroTools: MacroTools
+using ModelingToolkit: ModelingToolkit, parameters, solve
+using Optim: Optim
+using Parameters: Parameters, @unpack
+using Random: Random
+using RecursiveArrayTools: RecursiveArrayTools
+using Requires: Requires
+using SciMLStructures: SciMLStructures
+using StanSample: StanSample, SampleModel, read_samples, stan_sample
+using TransformVariables: TransformVariables, as, asℝ₊
+using TransformedLogDensities: TransformedLogDensities, TransformedLogDensity
+using Turing: Turing, Bernoulli, Beta, BetaBinomial, Binomial, Categorical,
+              Cauchy, Chisq, Distributions, Exponential, Frechet, Gamma,
+              GeneralizedPareto, Gumbel, Hypergeometric, InverseGamma, Laplace,
+              LogNormal, MCMCSerial, MvNormal, NamedDist, NegativeBinomial,
+              Normal, Pareto, Poisson, Rayleigh, TDist, Truncated, Uniform,
+              VonMises, Weibull, logpdf, params, sample
 
 STANDARD_PROB_GENERATOR(prob, p) = remake(prob; u0 = eltype(p).(prob.u0), p = p)
 function STANDARD_PROB_GENERATOR(prob::EnsembleProblem, p)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -31,5 +31,5 @@ run_qa(
     # DiffEqBayes pulls 68 names implicitly from heavy `using` deps (Turing,
     # Distributions, ModelingToolkit, DiffEqBase, ...); making them explicit is a
     # large, risky refactor tracked in https://github.com/SciML/DiffEqBayes.jl/issues/391
-    ei_broken = (:no_implicit_imports,)
+    ei_broken = ()
 )


### PR DESCRIPTION
Adds a pointer to the Turing.jl Bayesian Differential Equations tutorial
in the documentation, directing users who want more control towards direct
Turing.jl usage.

Fixes #247