### PR TITLE
Add Turing.jl direct usage tutorial link (fixes #247)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,6 +15,13 @@ using Pkg
 Pkg.add("DiffEqBayes")
 ```
 
+## Direct Turing.jl Usage
+
+While DiffEqBayes.jl provides a simplified interface, users who want more control
+can use Turing.jl directly with DifferentialEquations.jl. See the
+[Turing.jl Bayesian Differential Equations tutorial](https://turinglang.org/docs/tutorials/bayesian-differential-equations/)
+for a complete guide on writing custom `@model` macros with ODE solvers.
+
 ## Contributing
 
   - Please refer to the


### PR DESCRIPTION
Adds a pointer to the Turing.jl Bayesian Differential Equations tutorial
in the documentation, directing users who want more control towards direct
Turing.jl usage.

Fixes #247