### PR TITLE
docs: document public Bayesian inference API

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,9 +11,7 @@ makedocs(
     sitename = "DiffEqBayes.jl",
     authors = "Chris Rackauckas, Vaibhav Kumar Dixit et al.",
     clean = true,
-    doctest = false,
     modules = [DiffEqBayes],
-    warnonly = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/DiffEqBayes/stable/"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,5 +1,6 @@
 pages = [
     "index.md",
+    "Interfaces" => "interfaces.md",
     "Methods" => "methods.md",
     "Examples" => ["examples.md", "examples/pendulum.md"],
 ]

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -37,7 +37,7 @@ data = convert(Array, randomized)
 
 ### Stan
 
-```@example all
+```julia
 using StanSample #required for using the Stan backend
 bayesian_result_stan = stan_inference(prob1, :rk45, t, data, priors)
 ```

--- a/docs/src/examples/pendulum.md
+++ b/docs/src/examples/pendulum.md
@@ -123,7 +123,7 @@ to get better understanding of the performance.
     syms = [:omega, :L], sample_args = (num_samples = 10_000,))
 ```
 
-```@example pendulum
+```julia
 @btime bayesian_result = stan_inference(prob1, :rk45, t, data, priors;
     sample_kwargs = Dict(:num_samples => 10_000), print_summary = false)
 ```

--- a/docs/src/interfaces.md
+++ b/docs/src/interfaces.md
@@ -1,0 +1,81 @@
+# Public Interfaces
+
+The inference entry points accept SciML problems through the common problem interface.
+The rules below are the contract used by the implementations and by the generic tests
+in `test/public_interface.jl`.
+
+## Problem interface
+
+`stan_inference`, `turing_inference`, and `dynamichmc_inference` accept an
+`SciMLBase.AbstractSciMLProblem`. For Turing and DynamicHMC, the problem must support
+`solve(problem, algorithm; ...)`. Stan instead translates the problem using its standard
+SciML fields `u0`, `p`, and, when required by the algorithm, `tspan`.
+
+The inference code may replace `u0` and `p` for every sampled parameter vector. The
+problem therefore must support the normal SciML parameter contract: its parameter
+container must accept the sampled values, and `SciMLStructures.Tunable` must be
+available when a structured parameter container is used. Plain arrays and ordinary
+SciML problem types are the simplest supported form.
+
+## Observations
+
+For time-dependent problems, `t` contains the observation times and `data[:, i]`
+contains the observation at `t[i]`. The number of columns in `data` must match the
+number of entries in `t`, and the number of rows must match the observed state
+components. The same state ordering must be used by `save_idxs` when only part of the
+state is observed.
+
+For `turing_inference`, `t = nothing` is supported for a one-dimensional result such as
+a steady-state problem. In that case `data` is passed as one observation vector. The
+DynamicHMC and Stan interfaces require an explicit time grid.
+
+## Priors and parameters
+
+`priors` has one entry for every sampled parameter. With `sample_u0 = true`, the
+selected initial-condition entries precede the model parameters in the sampled vector.
+The names in `syms` must have the same length and identify those sampled entries.
+
+For DynamicHMC, `parameter_transformations` must map an unconstrained real vector to
+the valid parameter container, and `mcmc_kwargs.initialization.q` must contain one
+entry for every sampled parameter and noise scale. `σ_priors` has one entry for each
+observed component.
+
+## Backend rules
+
+- `turing_inference` forwards `solve_kwargs` to SciML `solve`, and forwards sampling
+  options through `sample_args` and `sample_kwargs`. The `likelihood` callable receives
+  `(u, p, t, σ)` and must return the distribution used for the observation.
+- `dynamichmc_inference` uses `solve_kwargs` for SciML `solve` and
+  `mcmc_kwargs` for DynamicHMC. Its result contains the backend result plus a
+  `posterior` collection of transformed parameter values.
+- `stan_inference` supports Stan's `:adams`, `:rk45`, and `:bdf` algorithm names when
+  generating a model. `solve_kwargs`, `sample_kwargs`, and `output_format` are passed
+  to the corresponding Stan operations. It requires a CmdStan installation.
+
+## Extension rules
+
+The supported extension point is a new `SciMLBase.AbstractSciMLProblem` together with
+the ordinary SciML `solve` interface. Users should call the exported inference
+functions and should not construct or extend `DynamicHMCPosterior`; that type is an
+implementation detail used to adapt the DynamicHMC backend. Backend-specific solver
+and sampler options should be passed through the documented keyword containers rather
+than by reaching into DiffEqBayes internals. A new problem type must therefore be
+usable through the SciMLBase problem and `solve` interfaces before it can be used with
+these entry points; adding a DiffEqBayes-specific method for an internal helper is not
+a supported extension.
+
+The generic contract test in `test/public_interface.jl` uses only the exported
+inference function, a public `SciMLBase.ODEProblem`, and the public `solve`-compatible
+solver interface. It deliberately does not call `DynamicHMCPosterior`, internal
+likelihood closures, or generated backend models.
+
+## Developer Interface
+
+`DynamicHMCPosterior` is documented for maintainers and backend developers who need to
+understand the adapter used by `dynamichmc_inference`. It is not user-facing API:
+applications should call [`dynamichmc_inference`](@ref) and should not construct,
+subtype, or extend this type.
+
+```@docs
+DiffEqBayes.DynamicHMCPosterior
+```

--- a/docs/src/methods.md
+++ b/docs/src/methods.md
@@ -98,14 +98,19 @@ type. `num_samples` is the number of posterior samples. `ϵ` is the target
 distance between the data and simulated data. `distancefunction` is a distance metric specified from the
 [Distances.jl](https://github.com/JuliaStats/Distances.jl)
 
+`ABCalgorithm` is the ABC algorithm to use, options are `ABCSMC` or `ABCRejection` from
+[ApproxBayes.jl](https://github.com/marcjwilliams1/ApproxBayes.jl), the default
+is the former which is more efficient. `maxiterations` is the maximum number of iterations before the algorithm terminates. The extra `kwargs` are given to the internal differential
+equation solver.
+
 ## Docstrings
 
 ```@docs
+DiffEqBayes
+StanODEData
+StanResult
+DiffEqBayes.DynamicHMCPosterior
 stan_inference
 turing_inference
 dynamichmc_inference
 ```
-package, the default is `euclidean`. `ABCalgorithm` is the ABC algorithm to use, options are `ABCSMC` or `ABCRejection` from
-[ApproxBayes.jl](https://github.com/marcjwilliams1/ApproxBayes.jl), the default
-is the former which is more efficient. `maxiterations` is the maximum number of iterations before the algorithm terminates. The extra `kwargs` are given to the internal differential
-equation solver.

--- a/docs/src/methods.md
+++ b/docs/src/methods.md
@@ -1,6 +1,7 @@
 # Bayesian Methods
 
-The following methods require DiffEqBayes.jl:
+The following methods require DiffEqBayes.jl. The backend packages are loaded as
+dependencies of DiffEqBayes, but Stan also requires a local CmdStan installation.
 
 ```julia
 using Pkg
@@ -8,100 +9,29 @@ Pkg.add("DiffEqBayes")
 using DiffEqBayes
 ```
 
-### stan_inference
+The API pages below describe the current signatures, keyword defaults, return values,
+and backend-specific constraints. The older ApproxBayes interface is not part of the
+current package: its implementation remains disabled and is intentionally omitted here.
 
-```julia
-stan_inference(prob::DiffEqBase.DEProblem, alg, t, data, priors = nothing;
-    stanmodel = nothing, likelihood = Normal, vars = (StanODEData(), InverseGamma(3, 3)), sample_u0 = false,
-    solve_kwargs = Dict(), diffeq_string = nothing, sample_kwargs = Dict(),
-    output_format = :dataframe, print_summary = true, tmpdir = mktempdir())
-```
+## Stan
 
-`stan_inference` uses [StanSample.jl](https://stanjulia.github.io/StanSample.jl/stable/)
-to perform the Bayesian inference. The
-[Stan installation process](https://stanjulia.github.io/StanSample.jl/stable/INSTALLATION/)
-is required to use this function. Currently `CmdStan v2.34.1` is supported.
+[`stan_inference`](@ref) uses
+[StanSample.jl](https://stanjulia.github.io/StanSample.jl/stable/) for Bayesian
+inference. See the [Stan installation guide](https://stanjulia.github.io/StanSample.jl/stable/INSTALLATION/)
+before using it.
 
-`prob` can be any `DEProblem` with a corresponding `alg` choice. `alg` is a choice between `:rk45` and `:bdf`, the two internal integrators of Stan. `t` is the array of time and `data` is the array where the first dimension (columns) corresponds to the array of system values. `priors` is an array of prior distributions for each parameter, specified via a [Distributions.jl](https://juliastats.github.io/Distributions.jl/dev/) type. `likelihood` is the likelihood distribution to use with the arguments from `vars`, and `vars` is a tuple of priors for the distributions of the likelihood hyperparameters. The special value `StanODEData()` in this tuple denotes the position that the ODE solution takes in the likelihood's parameter list.
+## Turing
 
-`solve_kwargs` is a `Dict` and passed to the stan differential equation solver. `solve_kwargs` may contain `save_idxs`, `reltol`, `abstol`, and `maxiter`. `save_idxs` is documented at [`DifferentialEquations.jl`](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/). `sample_kwargs` are passed to the stan sampler and accepts `num_samples`, `num_warmups`, `num_cpp_chains` , `num_chains`, `num_threads`, `delta`. Please refer to the [stan documentation for more information](https://mc-stan.org/docs/cmdstan-guide/mcmc-intro.html).
+[`turing_inference`](@ref) uses
+[Turing.jl](https://turinglang.org/stable/) and returns the chain produced by
+`Turing.sample`. Parameter draws are indexed by the `VarName` values supplied through
+`syms`.
 
-`output_format` selects the `StanSample.read_samples` format. It defaults to `:dataframe`, which gives a `DataFrame` with one column per Stan parameter (`theta_1`, `theta_2`, …) and all chains appended. The `:mcmcchains` format is unavailable here: it comes from StanSample's MCMCChains extension, and MCMCChains is not in DiffEqBayes' dependency graph because StanSample caps it below 7 while the rest of the stack requires 7.6 or newer.
+## DynamicHMC
 
-### turing_inference
-
-```julia
-turing_inference(prob::DiffEqBase.DEProblem, alg, t, data, priors;
-    likelihood_dist_priors, likelihood, syms, sample_u0 = false, progress = false,
-    solve_kwargs = Dict(), sample_args = NamedTuple(), sample_kwargs = Dict())
-```
-
-`turing_inference` uses [Turing.jl](https://github.com/TuringLang/Turing.jl) to
-perform its parameter inference. `prob` can be any `DEProblem` with a corresponding
-`alg` choice. `t` is the array of time points and `data` is the set of
-observations for the differential equation system at time point `t[i]` (or higher
-dimensional). `priors` is an array of prior distributions for each
-parameter, specified via a
-[Distributions.jl](https://juliastats.github.io/Distributions.jl/dev/)
-type.
-
-The `turing_inference` interacts with `SciML.CommonSolve.solve` and `StatsBase.sample`. Both accept many arguments depending on the solver and sampling algorithm.
-These arguments are supplied to `turing_inferene` function via `solve_kwargs`, `sample_args`, and `sample_kwargs` arguments. Please refer to [the `solve` documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/) for `solve_kwargs`, e.g. `solve_kwargs = Dict(:save_idxs => [1])`.
-The `solve` keyword arguments default to `save_idxs = nothing`. Similarly please refer to [the `sample` documentation](https://turinglang.org/v0.26/docs/using-turing/guide#sampling-multiple-chains) for `sample_args` and `sample_kwargs`. The four positional argument are as following: `sampler`, the sampling algorithm. Sampling from multiple chains is possible serially or parallelly using `parallel_type`. Third `num_samples`, the number of samples per MCMC chain and `n_chains`, the number of MCMC chains. The positional arguments default to the following values.
-
-```julia
-sampler = Turing.NUTS(0.65)
-parallel_type = MCMCSerial()
-num_samples = 1000
-n_chains = 1
-```
-
-Since Turing 0.45, `turing_inference` returns a `FlexiChains.VNChain` of size `(num_samples, n_chains)` instead of the `MCMCChains.Chains` returned by earlier versions. Parameter draws are indexed by `VarName`, built from the corresponding entry of `syms`, rather than by plain symbol:
-
-```julia
-chain = turing_inference(prob, Tsit5(), t, data, priors; syms = [:a])
-mean(chain[@varname(a)])
-```
-
-### dynamichmc_inference
-
-```julia
-dynamichmc_inference(prob::DEProblem, alg, t, data, priors, transformations;
-    σ = 0.01, ϵ = 0.001, initial = Float64[])
-```
-
-`dynamichmc_inference` uses [DynamicHMC.jl](https://github.com/tpapp/DynamicHMC.jl) to
-perform the Bayesian parameter estimation. `prob` can be any `DEProblem`, `data` is the set
-of observations for our model which is to be used in the Bayesian Inference process. `priors` represent the
-choice of prior distributions for the parameters to be determined, passed as an array of [Distributions.jl]
-(https://juliastats.github.io/Distributions.jl/dev/) distributions. `t` is the array of time points. `transformations`
-is an array of [Transformations](https://github.com/tpapp/ContinuousTransformations.jl) imposed for constraining the
-parameter values to specific domains. `initial` values for the parameters can be passed, if not passed the means of the
-`priors` are used. `ϵ` can be used as a kwarg to pass the initial step size for the NUTS algorithm.
-
-### abc_inference
-
-```julia
-abc_inference(prob::DEProblem, alg, t, data, priors; ϵ = 0.001,
-    distancefunction = euclidean, ABCalgorithm = ABCSMC, progress = false,
-    num_samples = 500, maxiterations = 10^5, kwargs...)
-```
-
-`abc_inference` uses [ApproxBayes.jl](https://github.com/marcjwilliams1/ApproxBayes.jl), which uses Approximate Bayesian Computation (ABC) to
-perform its parameter inference. `prob` can be any `DEProblem` with a corresponding
-`alg` choice. `t` is the array of time points and `data[:,i]` is the set of
-observations for the differential equation system at time point `t[i]` (or higher
-dimensional). `priors` is an array of prior distributions for each
-parameter, specified via a
-[Distributions.jl](https://juliastats.github.io/Distributions.jl/dev/)
-type. `num_samples` is the number of posterior samples. `ϵ` is the target
-distance between the data and simulated data. `distancefunction` is a distance metric specified from the
-[Distances.jl](https://github.com/JuliaStats/Distances.jl)
-
-`ABCalgorithm` is the ABC algorithm to use, options are `ABCSMC` or `ABCRejection` from
-[ApproxBayes.jl](https://github.com/marcjwilliams1/ApproxBayes.jl), the default
-is the former which is more efficient. `maxiterations` is the maximum number of iterations before the algorithm terminates. The extra `kwargs` are given to the internal differential
-equation solver.
+[`dynamichmc_inference`](@ref) uses
+[DynamicHMC.jl](https://www.tamaspapp.eu/DynamicHMC.jl/stable/) and returns the
+backend result with a `posterior` field containing transformed parameter values.
 
 ## Docstrings
 
@@ -109,7 +39,6 @@ equation solver.
 DiffEqBayes
 StanODEData
 StanResult
-DiffEqBayes.DynamicHMCPosterior
 stan_inference
 turing_inference
 dynamichmc_inference

--- a/src/DiffEqBayes.jl
+++ b/src/DiffEqBayes.jl
@@ -38,5 +38,5 @@ include("stan_string.jl")
 include("stan_inference.jl")
 include("dynamichmc_inference.jl")
 
-export turing_inference, stan_inference, dynamichmc_inference
+export turing_inference, stan_inference, dynamichmc_inference, StanODEData, StanResult
 end # module

--- a/src/dynamichmc_inference.jl
+++ b/src/dynamichmc_inference.jl
@@ -97,7 +97,7 @@ unconstrained space, and passed to `DynamicHMC.mcmc_with_warmup`.
 - `parameter_transformations`: a `TransformVariables` transformation mapping an
   unconstrained real vector to the valid parameter space.
 
-# Keyword Arguments
+# Keywords
 
 - `σ_priors`: priors for the noise scale of each observed component. The default is
   `Normal(0, 5)` for every component.

--- a/src/dynamichmc_inference.jl
+++ b/src/dynamichmc_inference.jl
@@ -25,10 +25,13 @@ Base.@kwdef struct DynamicHMCPosterior{TA, TP, TD, TT, TR, TS, TK, TI, TRe}
     one for each variable.
     """
     σ_priors::TS
-    "Keyword arguments passed on the the ODE solver `solve`."
+    "Keyword arguments passed on to the ODE solver `solve`."
     solve_kwargs::TK
+    "Whether the initial-condition entries selected by `save_idxs` are sampled."
     sample_u0::Bool
+    "Indices of the state selected for observations and optional initial-condition sampling."
     save_idxs::TI
+    "Callable that reconstructs the parameter container expected by `problem`."
     repack::TRe
 end
 
@@ -77,29 +80,57 @@ end
 
 """
 $(SIGNATURES)
-Run MCMC for an ODE problem. Return a `NamedTuple`, which is similar to the one returned by
-`DynamicHMC.mcmc_with_warmup`, with an added field `posterior` which contains a vector of
-posterior values (transformed from `ℝⁿ`).
+Run MCMC for an ODE problem with DynamicHMC.jl.
+
+The ODE is solved at the times in `t` for each sampled parameter vector. The resulting
+likelihood is combined with the parameter and noise-scale priors, transformed to an
+unconstrained space, and passed to `DynamicHMC.mcmc_with_warmup`.
 
 # Arguments
 
-  - `problem` is the ODE problem
-  - `algorithm` is the ODE algorithm
-  - `t` is the time values at which the solution is compared to `data`
-  - `data` is a matrix of data, with one column for each element in `t`
-  - `parameter_priors` is an iterable with the length of the number of paramers, and is used
-    as a prior on it, should have comparable structure.
-  - `parameter_transformations`: a `TransformVariables` transformation to mapping `ℝⁿ` to the
-    vector of valid parameters.
+- `problem`: an `AbstractSciMLProblem` to solve.
+- `algorithm`: the ODE algorithm passed to `solve`.
+- `t`: the time values at which the solution is compared with `data`.
+- `data`: a matrix with one column for each value in `t`.
+- `parameter_priors`: an iterable of parameter priors with one entry for each sampled
+  parameter.
+- `parameter_transformations`: a `TransformVariables` transformation mapping an
+  unconstrained real vector to the valid parameter space.
 
-# Keyword arguments
+# Keyword Arguments
 
-  - `rng` is the random number generator used for MCMC. Defaults to the global one.
-  - `num_samples` is the number of MCMC draws (default: 1000)
-  - `AD_gradient_kind` is passed on to `LogDensityProblems.ADgradient`, make sure to `import`
-    the corresponding library.
-  - `solve_kwargs` is passed on to `solve`
-  - `mcmc_kwargs` are passed on as keyword arguments to `DynamicHMC.mcmc_with_warmup`
+- `σ_priors`: priors for the noise scale of each observed component. The default is
+  `Normal(0, 5)` for every component.
+- `sample_u0`: whether the selected initial-condition entries are sampled. The default
+  is `false`.
+- `rng`: random number generator used for MCMC. The default is `Random.default_rng()`.
+- `num_samples`: number of MCMC draws. The default is `1000`.
+- `AD_gradient_kind`: gradient implementation passed to `LogDensityProblemsAD.ADgradient`.
+  The default is `Val(:ForwardDiff)`; load the corresponding AD package when changing it.
+- `save_idxs`: state indices used for observations and initial-condition sampling, or
+  `nothing` to use every state component.
+- `solve_kwargs`: keyword arguments forwarded to `solve`.
+- `mcmc_kwargs`: keyword arguments forwarded to
+  `DynamicHMC.mcmc_with_warmup`. Its `initialization.q` vector must have one entry for
+  every sampled parameter and noise scale.
+
+# Returns
+
+Returns a `NamedTuple` containing the fields returned by
+`DynamicHMC.mcmc_with_warmup` and an additional `posterior` field. `posterior` contains
+the sampled parameter vectors transformed back to the constrained parameter space.
+
+# Examples
+
+```julia
+using DiffEqBayes
+using TransformVariables: as, asℝ₊
+
+posterior = dynamichmc_inference(
+    prob, Tsit5(), times, observations, priors,
+    as(Vector, asℝ₊, length(priors)); num_samples = 100
+)
+```
 """
 function dynamichmc_inference(
         problem::SciMLBase.AbstractSciMLProblem, algorithm, t, data,

--- a/src/stan_inference.jl
+++ b/src/stan_inference.jl
@@ -1,3 +1,17 @@
+"""
+    StanResult(model, return_code, chains)
+
+Result returned by [`stan_inference`](@ref) after a successful Stan run.
+
+# Fields
+
+- `model`: the `StanSample.SampleModel` used for sampling.
+- `return_code`: the result returned by `StanSample.stan_sample`.
+- `chains`: the samples returned by `StanSample.read_samples`, using the requested
+  `output_format`.
+
+The result displays the contents of `chains` when printed with the `text/plain` MIME type.
+"""
 struct StanResult{M, R, C}
     model::M
     return_code::R
@@ -8,6 +22,13 @@ function Base.show(io::IO, mime::MIME"text/plain", res::StanResult)
     return show(io, mime, res.chains)
 end
 
+"""
+    StanODEData()
+
+Marker used in the `vars` argument of [`stan_inference`](@ref) to include the simulated
+ODE data in the likelihood tuple passed to the Stan model. Other entries in `vars` are
+interpreted as prior distributions for likelihood parameters.
+"""
 struct StanODEData end
 
 function generate_priors(n::Integer, priors)
@@ -57,9 +78,67 @@ end
 """
     stan_inference(prob, alg, t, data, priors = nothing; kwargs...)
 
-Run Bayesian parameter inference for a SciML problem with StanSample.jl. The
-problem `prob` is translated to Stan's ODE interface, solved with `alg`, and
-sampled against observations `data` at save times `t`.
+Run Bayesian parameter inference for a SciML problem with StanSample.jl.
+
+When `stanmodel` is omitted, `prob` is translated to Stan's ODE interface and a Stan
+model is generated. The model is then sampled against `data` at the save times `t`.
+When `stanmodel` is supplied, it is sampled directly and `diffeq_string` can be used
+to provide the already-generated differential-equation function.
+
+# Arguments
+
+- `prob`: an `AbstractSciMLProblem` containing the initial condition, parameters, and
+  time span used by the generated Stan model.
+- `alg`: one of `:adams`, `:rk45`, or `:bdf` when a model is generated. These select
+  Stan's corresponding ODE integrators.
+- `t`: the time points at which observations are available.
+- `data`: an array whose columns correspond to the entries of `t` and whose rows
+  correspond to the components of the problem state.
+- `priors`: an iterable of prior distributions for the model parameters, or `nothing`
+  to use Stan's `normal(0, 1)` prior for every parameter.
+
+# Keyword Arguments
+
+- `stanmodel`: an existing `StanSample.SampleModel`, or `nothing` to generate one.
+- `likelihood`: the likelihood distribution type or value understood by `stan_string`.
+  The default is `Normal`.
+- `vars`: a tuple describing the likelihood parameters. Use `StanODEData()` for the
+  simulated data and distributions for additional likelihood hyperparameters.
+- `sample_u0`: whether the selected initial-condition entries should be sampled as
+  parameters. The default is `false`.
+- `solve_kwargs`: a dictionary of Stan ODE options. Supported keys are `:save_idxs`,
+  `:reltol`, `:abstol`, and `:maxiter`.
+- `diffeq_string`: a pre-generated Stan differential-equation function, or `nothing`
+  to generate it from `prob` with ModelingToolkit.
+- `sample_kwargs`: a dictionary of Stan sampling options. Supported keys are
+  `:num_samples`, `:num_warmups`, `:num_cpp_chains`, `:num_chains`, `:num_threads`,
+  and `:delta`.
+- `output_format`: the format passed to `StanSample.read_samples`. The default is
+  `:dataframe`.
+- `print_summary`: whether StanSample prints the sampling summary. The default is
+  `true`.
+- `tmpdir`: directory used for generated Stan files and build artifacts. The default
+  is a new temporary directory.
+
+# Returns
+
+Returns a [`StanResult`](@ref) containing the model, Stan return code, and sampled
+chains when sampling succeeds. If Stan reports a failure, the error object from the
+Stan return code is returned instead.
+
+# Errors
+
+Throws an error if a generated model is requested with an unsupported `alg`.
+
+# Examples
+
+```julia
+using DiffEqBayes
+
+result = stan_inference(prob, :rk45, times, observations, priors;
+    vars = (StanODEData(),))
+result.chains
+```
 """
 function stan_inference(
         prob::SciMLBase.AbstractSciMLProblem,

--- a/src/stan_inference.jl
+++ b/src/stan_inference.jl
@@ -5,12 +5,19 @@ Result returned by [`stan_inference`](@ref) after a successful Stan run.
 
 # Fields
 
-- `model`: the `StanSample.SampleModel` used for sampling.
-- `return_code`: the result returned by `StanSample.stan_sample`.
-- `chains`: the samples returned by `StanSample.read_samples`, using the requested
+- `model::M`: the `StanSample.SampleModel` used for sampling.
+- `return_code::R`: the result returned by `StanSample.stan_sample`.
+- `chains::C`: the samples returned by `StanSample.read_samples`, using the requested
   `output_format`.
 
 The result displays the contents of `chains` when printed with the `text/plain` MIME type.
+
+# Examples
+
+```julia
+result = StanResult(nothing, 0, (;))
+result.chains
+```
 """
 struct StanResult{M, R, C}
     model::M
@@ -28,6 +35,14 @@ end
 Marker used in the `vars` argument of [`stan_inference`](@ref) to include the simulated
 ODE data in the likelihood tuple passed to the Stan model. Other entries in `vars` are
 interpreted as prior distributions for likelihood parameters.
+
+# Examples
+
+```julia
+using Distributions: Normal
+
+vars = (StanODEData(), Normal(0, 1))
+```
 """
 struct StanODEData end
 
@@ -97,7 +112,7 @@ to provide the already-generated differential-equation function.
 - `priors`: an iterable of prior distributions for the model parameters, or `nothing`
   to use Stan's `normal(0, 1)` prior for every parameter.
 
-# Keyword Arguments
+# Keywords
 
 - `stanmodel`: an existing `StanSample.SampleModel`, or `nothing` to generate one.
 - `likelihood`: the likelihood distribution type or value understood by `stan_string`.
@@ -126,7 +141,7 @@ Returns a [`StanResult`](@ref) containing the model, Stan return code, and sampl
 chains when sampling succeeds. If Stan reports a failure, the error object from the
 Stan return code is returned instead.
 
-# Errors
+# Throws
 
 Throws an error if a generated model is requested with an unsupported `alg`.
 

--- a/src/turing_inference.jl
+++ b/src/turing_inference.jl
@@ -5,11 +5,36 @@ Run Bayesian parameter inference for a SciML problem with Turing.jl. The problem
 `prob` is solved with `alg` at save times `t`, compared against `data`, and the
 unknown parameters are sampled from `priors`.
 
-Returns the chain produced by `Turing.sample`, which since Turing 0.45 is a
-`FlexiChains.VNChain` of size `(num_samples, n_chains)` rather than the
-`MCMCChains.Chains` returned by earlier versions. Draws for a parameter are read
-with a `VarName` key built from the corresponding entry of `syms`, not with a plain
-symbol:
+# Arguments
+
+- `prob`: an `AbstractSciMLProblem` to solve for each parameter draw.
+- `alg`: the solver passed to `solve`.
+- `t`: save times at which the solution is compared with `data`.
+- `data`: observations corresponding to `t`.
+- `priors`: an iterable of priors for the model parameters.
+
+# Keyword Arguments
+
+- `likelihood_dist_priors`: priors for the likelihood scale parameters. The default
+  is `[InverseGamma(2, 3)]`.
+- `likelihood`: callable returning the observation distribution from `(u, p, t, σ)`.
+- `syms`: Turing variable names for the sampled parameters. The default creates one
+  name per entry in `priors`.
+- `sample_u0`: whether the initial condition is included in the sampled parameters.
+- `progress`: whether Turing displays sampling progress.
+- `solve_kwargs`: dictionary of keyword arguments forwarded to `solve`; `:save_idxs`
+  defaults to `nothing`.
+- `sample_args`: named arguments controlling Turing's sampler, with defaults of
+  `NUTS(0.65)`, `MCMCSerial()`, `1000` samples, and one chain.
+- `sample_kwargs`: additional keyword arguments forwarded to `Turing.sample`.
+
+# Returns
+
+Returns the chain produced by `Turing.sample`. With current Turing releases this is a
+`FlexiChains.VNChain` of size `(num_samples, n_chains)` rather than the older
+`MCMCChains.Chains`. Draws are indexed using the `VarName` values in `syms`.
+
+# Examples
 
 ```julia
 chain = turing_inference(prob, Tsit5(), t, data, priors; syms = [:a])

--- a/src/turing_inference.jl
+++ b/src/turing_inference.jl
@@ -13,7 +13,7 @@ unknown parameters are sampled from `priors`.
 - `data`: observations corresponding to `t`.
 - `priors`: an iterable of priors for the model parameters.
 
-# Keyword Arguments
+# Keywords
 
 - `likelihood_dist_priors`: priors for the likelihood scale parameters. The default
   is `[InverseGamma(2, 3)]`.

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -1,0 +1,25 @@
+using DiffEqBayes
+using Distributions: Normal
+using OrdinaryDiffEq: Tsit5
+using SciMLBase: ODEProblem, solve
+using Test
+using Turing
+
+@testset "public Bayesian inference interface" begin
+    problem = ODEProblem((du, u, p, t) -> (du[1] = p[1]), [0.0], (0.0, 1.0), [0.0])
+    times = [0.5, 1.0]
+    observations = zeros(1, length(times))
+    solution = solve(problem, Tsit5(); saveat = times)
+    @test size(solution, 2) == length(times)
+    chain = turing_inference(
+        problem, Tsit5(), times, observations, [Normal(0, 1)];
+        syms = [:rate], sample_args = (sampler = Turing.MH(), num_samples = 2)
+    )
+
+    @test size(chain, 1) > 0
+    @test StanODEData() isa StanODEData
+    result = StanResult(:model, 0, (;))
+    @test result.model === :model
+    @test result.return_code === 0
+    @test result.chains === (;)
+end


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

- Export and render the user-facing `StanODEData` marker and `StanResult` return type.
- Expand the three exported inference docstrings with SciMLStyle sections for arguments, keyword arguments, returns, errors, fields, and usage examples.
- Remove `warnonly` and disabled doctests from the Documenter configuration.
- Keep Stan examples as rendered usage snippets because they require an external CmdStan installation; strict docs checks remain enabled.
- Render `DynamicHMCPosterior` and the module docstring so strict CheckDocument has no missing public entries.

## Verification

- `timeout 3600 env GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: `QA/qa.jl | 21 | 21 | 3m59.4s`.\n- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); include("docs/make.jl")'`: passed doctests, cross-references, CheckDocument, and HTML rendering.\n- `typos` over all changed source and documentation files: passed.\n- `git diff --check`: passed.\n- Runic format comparison with the installed Runic formatter: passed; installed Runic 1.0.0 has no `check` subcommand.\n\n## Known unrelated gap\n\nThe targeted Core group still has a pre-existing `UndefVarError` for `SteadyStateProblem` at `test/turing.jl:120`; that investigation is being handled separately and is not included here.