### PR TITLE
test: import SteadyStateProblem from SciMLBase

### DIFF
--- a/test/turing.jl
+++ b/test/turing.jl
@@ -1,5 +1,6 @@
 using DiffEqBayes, OrdinaryDiffEq, ParameterizedFunctions, RecursiveArrayTools
 using Test, Distributions, SteadyStateDiffEq
+using SciMLBase: SteadyStateProblem
 using Turing, ADTypes
 
 println("One parameter case")


### PR DESCRIPTION
## Summary

`test/turing.jl` used `SteadyStateProblem` through the former blanket `SteadyStateDiffEq` reexport. The explicit SciMLTesting 2.4 public-API cleanup in SteadyStateDiffEq removed that transitive export, so the Core test now fails with `UndefVarError`. Import the public name from its owning package, `SciMLBase`.

This is intentionally separate from the DiffEqBayes docs/public API PR.

## Bisect

On a clean checkout of `origin/master` at `33935c6` (`Set DiffEqBayes version to 3.14.4 (#406)`), the failure reproduces. A dependency-aware bisect of SteadyStateDiffEq identified the first bad commit:

`98d5fc9de2d453688c815fab1f01584a98ba6728` (`Adopt strict SciMLTesting 2.4 public API QA (#146)`).

That commit replaced `@reexport using SciMLBase` with explicit imports, so `SteadyStateProblem` remains available inside SteadyStateDiffEq but is no longer exported from it.

## Verification

Before this change, on clean `origin/master`:

```text
GROUP=Core julia --project --startup-file=no -e 'using Pkg; Pkg.test()'
Core/turing.jl |   13      1     14
UndefVarError: `SteadyStateProblem` not defined
test/turing.jl:120
```

After this change, the same command completed successfully:

```text
Core/turing.jl |   14     14  3m33.0s
Testing DiffEqBayes tests passed
```

The pre-existing `Core/dynamicHMC.jl` result remains `8 pass, 2 broken, 10 total`.

The QA group also passed:

```text
GROUP=QA julia --project --startup-file=no -e 'using Pkg; Pkg.test()'
QA/qa.jl |   21     21  3m57.8s
Testing DiffEqBayes tests passed
```

`typos test/turing.jl` and `git diff --check` passed. The installed `runic` executable is a repository orchestration wrapper (`init`, `integrate`, `mem`, `track`), not the SciML formatter, so no formatter check was available locally. No docs build was needed because this PR changes only a test import.

Please ignore this draft until reviewed by @ChrisRackauckas.
