### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBayes"
 uuid = "ebbdde9d-f333-5424-9be2-dbf1e9acfb5e"
 authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
-version = "3.14.4"
+version = "3.15.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Version bumps only -- no source changes.

Each package below has `src/` changes since its last registered version (verified by comparing the registry's recorded `git-tree-sha1` for that version against the current tree), but its `Project.toml` version still equals the registered one, so there is nothing to register.

Increment is minor, which is a valid standard increment under the General [sequential version number](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) guideline.

- DiffEqBayes 3.14.4 -> 3.15.0